### PR TITLE
feat: consolidate dependency updates

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -23,13 +23,13 @@ jobs:
 
           
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -48,7 +48,7 @@ jobs:
             type=sha,format=long,prefix=
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Consolidates the open Renovate GitHub Actions update PRs into one, validated in Docker.

## Included bumps (`.github/workflows/container_image.yaml`)
| Action | From | To | Supersedes |
|---|---|---|---|
| docker/build-push-action | v6.19.2 | **v7.2.0** | #77 |
| docker/metadata-action | v5.10.0 | **v6.1.0** | #76 |
| docker/setup-buildx-action | v3.12.0 | **v4.1.0** | #75 |
| docker/setup-qemu-action | v3 | **v4** | #74 |
| docker/login-action | v3.7.0 | **v4.2.0** | #73 |

All pinned to the exact Renovate SHA + version comment.

## Validation
- `docker build .` passes (the repo's own Dockerfile, in a container).
- The action bumps are CI-config only (not exercised by the image build); they take effect when `container_image.yaml` next runs on a tag.

## Excluded
None.

> Opened for review — not merged. Superseded Renovate PRs will be closed with a pointer here.
